### PR TITLE
from_dts() methods raise ParseExceptions on bad input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ test: test-lint
 
 UNIT_TESTS = tests/test_devicetree.py \
 	     tests/test_grammar.py \
+	     tests/test_exceptions.py \
 	     tests/test_overlay.py
 
 .PHONY: test-unit

--- a/pydevicetree/source/parser.py
+++ b/pydevicetree/source/parser.py
@@ -134,7 +134,7 @@ def recurseIncludeFiles(elements, pwd):
 
 def parseElements(dts, pwd="", followIncludes=False):
     """Parses a string into a list of elements"""
-    elements = grammar.devicetree.parseString(dts)
+    elements = grammar.devicetree.parseString(dts, parseAll=True)
     parentNodes(elements)
     if followIncludes:
         recurseIncludeFiles(elements, pwd)
@@ -146,11 +146,11 @@ def parseTree(dts, pwd="", followIncludes=False):
 
 def parseNode(dts):
     """Parses a string into a Devictreee Node"""
-    return grammar.node_definition.parseString(dts)[0]
+    return grammar.node_definition.parseString(dts, parseAll=True)[0]
 
 def parseProperty(dts):
     """Parses a string into a Devicetree Property"""
-    return grammar.property_assignment.parseString(dts)[0]
+    return grammar.property_assignment.parseString(dts, parseAll=True)[0]
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+
+from pydevicetree import *
+from pyparsing import ParseException
+
+class TestExceptions(unittest.TestCase):
+    def test_bad_tree(self):
+        with self.assertRaises(ParseException):
+            Devicetree.from_dts("/dts-v1/; / { } // No semicolon")
+        with self.assertRaises(ParseException):
+            Devicetree.from_dts("/dts-v1/; / { #address-cells = <10; /* missing '>' */ };")
+
+    def test_bad_node(self):
+        with self.assertRaises(ParseException):
+            Node.from_dts("/ { } // No semicolon")
+        with self.assertRaises(ParseException):
+            Node.from_dts("/ { #address-cells = <10; /* missing '>' */ };")
+
+    def test_bad_property(self):
+        with self.assertRaises(ParseException):
+            Property.from_dts("reg = <0x0 0x1> // no semicolon")
+        with self.assertRaises(ParseException):
+            Property.from_dts("reg = <0x0 0x1 /* missing '>' */;")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously, badly formatted input would silently fail. Instead, bad input results in a `pyparsing.ParseException`.