### PR TITLE
Describe labels, paths, and references with classes

### DIFF
--- a/pydevicetree/ast/__init__.py
+++ b/pydevicetree/ast/__init__.py
@@ -5,3 +5,4 @@
 from pydevicetree.ast.property import PropertyValues, Bytestring, CellArray, StringList, Property
 from pydevicetree.ast.directive import Directive
 from pydevicetree.ast.node import Node, NodeReference, Devicetree
+from pydevicetree.ast.reference import Label, Path, Reference, LabelReference, PathReference

--- a/pydevicetree/ast/helpers.py
+++ b/pydevicetree/ast/helpers.py
@@ -4,6 +4,8 @@
 
 from typing import List, Any
 
+from pydevicetree.ast.reference import Reference
+
 def formatLevel(level: int, s: str) -> str:
     """Helper to indent a string with a number of tabs"""
     return "\t" * level + s
@@ -12,11 +14,10 @@ def wrapStrings(values: List[Any], formatHex: bool = False) -> List[Any]:
     """Helper to wrap strings in quotes where appropriate"""
     wrapped = []
     for v in values:
-        if isinstance(v, str):
-            if v[0] != '&':
-                wrapped.append("\"%s\"" % v)
-            else:
-                wrapped.append(v)
+        if isinstance(v, Reference):
+            wrapped.append(v.to_dts())
+        elif isinstance(v, str):
+            wrapped.append("\"%s\"" % v)
         elif isinstance(v, int):
             if formatHex:
                 wrapped.append("0x%x" % v)

--- a/pydevicetree/ast/reference.py
+++ b/pydevicetree/ast/reference.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Union, Iterator, Optional
+
+class Label:
+    """A Label is a unique identifier for a Node
+
+    For example, the following node has the label "uart0":
+
+        uart0: uart@10013000 {
+            ...
+        };
+    """
+    def __init__(self, name: str):
+        """Create a Label"""
+        self.name = name
+
+    def __repr__(self) -> str:
+        return "<Label " + self.name + ">"
+
+    def __eq__(self, other: Union['Label', str]) -> bool:
+        if isinstance(other, Label):
+            return self.name == other.name
+        if isinstance(other, str):
+            return self.name == other
+        return False
+
+    def to_dts(self) -> str:
+        """Format the label in Devicetree Source format"""
+        return self.name + ":"
+
+class Path:
+    """A Path uniquely identifies a Node by its parents and (optionally) unit address"""
+    def __init__(self, path: str, address: Optional[int] = None):
+        """Create a path out of a string"""
+        self.path = list(filter(lambda s: s != '', path.split('/')))
+        self.address = address
+
+    def to_dts(self) -> str:
+        """Format the Path in Devicetree Source format"""
+        if self.address:
+            return '/%s@%x' % ('/'.join(self.path), self.address)
+        return '/' + '/'.join(self.path)
+
+    def __repr__(self) -> str:
+        return "<Path " + self.to_dts() + ">"
+
+    def __eq__(self, other: Union['Path', str]) -> bool:
+        if isinstance(other, Path):
+            return self.to_dts() == other.to_dts()
+        if isinstance(other, str):
+            return self.to_dts() == other
+        return False
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(['/'] + self.path)
+
+class Reference:
+    """A Reference is a Devicetree construct which points to a Node in the tree
+
+    The following are types of references:
+
+        - A reference to a label:
+
+            &my-label;
+
+        - A reference to a node by path:
+
+            &{/path/to/node@deadbeef}
+
+    This is the parent class for both types of references, LabelReference and PathReference
+    """
+
+class LabelReference(Reference):
+    """A LabelReference is a reference to a Node by label"""
+    def __init__(self, label: Union[Label, str]):
+        """Create a LabelReference from a Label or string"""
+        if isinstance(label, Label):
+            self.label = label
+        elif isinstance(label, str):
+            self.label = Label(label)
+
+    def __repr__(self) -> str:
+        return "<LabelReference " + self.to_dts() + ">"
+
+    def to_dts(self) -> str:
+        """Format the LabelReference in Devicetree Source format"""
+        return "&" + self.label.name
+
+class PathReference(Reference):
+    """A PathReference is a reference to a Node by path"""
+    def __init__(self, path: Union[Path, str]):
+        """Create a PathReference from a Path or string"""
+        if isinstance(path, Path):
+            self.path = path
+        elif isinstance(path, str):
+            self.path = Path(path)
+
+    def __repr__(self) -> str:
+        return "<PathReference " + self.to_dts() + ">"
+
+    def to_dts(self) -> str:
+        """Format the PathReference in Devicetree Source format"""
+        return "&{" + self.path.to_dts() + "}"

--- a/pydevicetree/source/grammar.py
+++ b/pydevicetree/source/grammar.py
@@ -14,10 +14,12 @@ label = p.Word(p.alphanums + "_").setResultsName("label")
 label_creation = p.Combine(label + p.Literal(":"))
 string = p.QuotedString(quoteChar='"')
 stringlist = p.delimitedList(string)
-node_path = p.Combine(p.Literal("/") + p.delimitedList(node_name, delim="/") + \
-        p.Optional(p.Literal("@") + unit_address))
-reference = p.Combine(p.Literal("&") + \
-        ((p.Literal("{") + node_path("path") + p.Literal("}")) ^ label))
+node_path = p.Combine(p.Literal("/") + \
+        p.delimitedList(node_name, delim="/", combine=True)).setResultsName("path") + \
+        p.Optional(p.Literal("@").suppress() + unit_address("address"))
+path_reference = p.Literal("&{").suppress() + node_path + p.Literal("}").suppress()
+label_reference = p.Literal("&").suppress() + label
+reference = path_reference ^ label_reference
 directive = p.QuotedString(quoteChar="/", unquoteResults=False).setResultsName("directive") + \
         p.Optional(string ^ property_name ^ node_name ^ reference ^ \
                 (integer * 2)).setResultsName("option") + p.Literal(";").suppress()
@@ -41,7 +43,7 @@ property_assignment = property_name("property_name") + p.Optional(p.Literal("=")
 
 node_opener = p.Optional(label_creation) + node_name("node_name") + \
         p.Optional(p.Literal("@").suppress() + unit_address("address")) + p.Literal("{").suppress()
-node_reference_opener = reference("node_reference") + p.Literal("{").suppress()
+node_reference_opener = reference + p.Literal("{").suppress()
 node_closer = p.Literal("}").suppress() + p.Literal(";").suppress()
 node_definition = p.Forward()
 # pylint: disable=expression-not-assigned

--- a/pydevicetree/source/parser.py
+++ b/pydevicetree/source/parser.py
@@ -13,8 +13,8 @@ def transformNode(string, location, tokens):
     directives = [e for e in tokens.asList() if isinstance(e, Directive)]
     children = [e for e in tokens.asList() if isinstance(e, Node)]
 
-    if tokens.node_reference:
-        return NodeReference(tokens.node_reference[0], properties=properties,
+    if isinstance(tokens[0], Reference):
+        return NodeReference(tokens[0], properties=properties,
                              directives=directives, children=children)
     return Node(tokens.node_name, tokens.label, tokens.address, properties=properties,
                 directives=directives, children=children)
@@ -69,6 +69,35 @@ def transformCellArray(string, location, tokens):
     """Transforms a ParseResult into a CellArray"""
     return CellArray(tokens.asList())
 
+def transformLabel(string, location, tokens):
+    """Transforms a ParseResult into a Label"""
+    return Label(tokens.label)
+
+def transformPath(string, location, tokens):
+    """Transforms a ParseResult into a Path"""
+    if tokens.address:
+        return Path(tokens.path, tokens.address)
+    return Path(tokens.path)
+
+def transformPathReference(string, location, tokens):
+    """Transforms a ParseResult into a PathReference"""
+    return PathReference(tokens[0])
+
+def transformLabelReference(string, location, tokens):
+    """Transforms a ParseResult into a LabelReference"""
+    return LabelReference(tokens[0])
+
+def transformReference(string, location, tokens):
+    """Transforms a ParseResult into a Reference"""
+    if isinstance(tokens[0], Reference):
+        return tokens[0]
+    return None
+
+grammar.label.setParseAction(transformLabel)
+grammar.node_path.setParseAction(transformPath)
+grammar.path_reference.setParseAction(transformPathReference)
+grammar.label_reference.setParseAction(transformLabelReference)
+grammar.reference.setParseAction(transformReference)
 grammar.node_definition.setParseAction(transformNode)
 grammar.property_assignment.setParseAction(transformPropertyAssignment)
 grammar.directive.setParseAction(transformDirective)

--- a/pylintrc
+++ b/pylintrc
@@ -146,7 +146,8 @@ disable=print-statement,
         unused-wildcard-import,
         invalid-name,
         unused-argument,
-        redefined-outer-name
+        redefined-outer-name,
+        too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -110,7 +110,7 @@ class TestDevicetree(unittest.TestCase):
 
         self.tree.chosen("my-cpu", func)
 
-        cpu = self.tree.get_by_reference("&{/cpus/cpu@0}")
+        cpu = self.tree.get_by_path("/cpus/cpu@0")
         self.assertEqual(type(cpu), Node)
         self.assertEqual(cpu.get_path(), "/cpus/cpu@0")
         self.assertEqual(cpu.get_field("reg"), 0)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -7,6 +7,19 @@ import unittest
 from pydevicetree.source.grammar import *
 
 class TestGrammar(unittest.TestCase):
+    def test_label(self):
+        from pydevicetree.ast import Label
+        self.assertEqual(label.parseString("mylabel:")[0], Label("mylabel"))
+
+    def test_node_path(self):
+        from pydevicetree.ast import Path
+        self.assertEqual(node_path.parseString("/path/to/foo@deadbeef")[0], Path("/path/to/foo@deadbeef"))
+
+    def test_reference(self):
+        from pydevicetree.ast import Label, Path
+        self.assertEqual(reference.parseString("&mylabel")[0].label, Label("mylabel"))
+        self.assertEqual(reference.parseString("&{/path/to/foo@deadbeef}")[0].path, Path("/path/to/foo@deadbeef"))
+
     def test_arith_expr(self):
         self.assertEqual(arith_expr.parseString("(1 + 2)").asList(), [3])
         self.assertEqual(arith_expr.parseString("(1 + 0xa)").asList(), [11])


### PR DESCRIPTION
Instead of treating Labels, Paths, and References as strings, describe them with their own classes.