### PR TITLE
Fix mypy type annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ upload: venv/bin/activate dist
 
 .PHONY: test-types
 test-types: venv/bin/activate
-	. $< && mypy -m unittest
+	. $< && mypy -m pydevicetree
 test: test-types
 
 .PHONY: test-lint

--- a/pydevicetree/ast/directive.py
+++ b/pydevicetree/ast/directive.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Any
+from typing import Any
 
 from pydevicetree.ast.helpers import formatLevel
 
@@ -23,10 +23,10 @@ class Directive:
     Their semantic meaning depends on the directive name, their location in the Devicetree,
     and their options.
     """
-    def __init__(self, directive: str, options: List[Any] = None):
+    def __init__(self, directive: str, option: Any = None):
         """Create a directive object"""
         self.directive = directive
-        self.options = options
+        self.option = option
 
     def __repr__(self) -> str:
         return "<Directive %s>" % self.directive
@@ -36,6 +36,6 @@ class Directive:
 
     def to_dts(self, level: int = 0) -> str:
         """Format the Directive in Devicetree Source format"""
-        if self.options:
-            return formatLevel(level, "%s %s;\n" % (self.directive, self.options))
+        if self.option:
+            return formatLevel(level, "%s %s;\n" % (self.directive, self.option))
         return formatLevel(level, "%s;\n" % self.directive)

--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -174,13 +174,13 @@ class Node:
         self.directives += other.directives
         self.children += other.children
 
-    def get_path(self) -> str:
+    def get_path(self, includeAddress: bool = True) -> str:
         """Get the path of a node (ex. /cpus/cpu@0)"""
         if self.name == "/":
             return ""
         if self.parent is None:
             return "/" + self.name
-        if isinstance(self.address, int):
+        if isinstance(self.address, int) and includeAddress:
             return self.parent.get_path() + "/" + self.name + "@" + ("%x" % self.address)
         return self.parent.get_path() + "/" + self.name
 
@@ -218,7 +218,13 @@ class Node:
 
     def get_by_path(self, path: Union[Path, str]) -> Optional['Node']:
         """Get a node in the subtree by path"""
-        matching_nodes = list(filter(lambda n: n.get_path() == path, self.child_nodes()))
+        matching_nodes = list(filter(lambda n: path == n.get_path(includeAddress=True), \
+                                     self.child_nodes()))
+        if len(matching_nodes) != 0:
+            return matching_nodes[0]
+
+        matching_nodes = list(filter(lambda n: path == n.get_path(includeAddress=False), \
+                                     self.child_nodes()))
         if len(matching_nodes) != 0:
             return matching_nodes[0]
         return None

--- a/pydevicetree/ast/property.py
+++ b/pydevicetree/ast/property.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Any
+from typing import List, Any, cast
 
 from pydevicetree.ast.helpers import wrapStrings, formatLevel
 
@@ -15,7 +15,7 @@ class PropertyValues:
         CellArray
         StringList
     """
-    def __init__(self, values: List[Any] = None):
+    def __init__(self, values: List[Any]):
         """Create a PropertyValue"""
         self.values = values
 
@@ -51,9 +51,9 @@ class Bytestring(PropertyValues):
 
         [de ad be eef]
     """
-    def __init__(self, bytelist: List[int] = None):
+    def __init__(self, bytelist: List[int]):
         """Create a Bytestring object"""
-        PropertyValues.__init__(self, bytearray(bytelist))
+        PropertyValues.__init__(self, cast(List[Any], bytearray(bytelist)))
 
     def __repr__(self) -> str:
         return "<Bytestring " + str(self.values) + ">"
@@ -70,7 +70,7 @@ class CellArray(PropertyValues):
     property encodes a CellArray as a list of tuples (base address, size), while the `interrupts`
     property encodes a CellArray as simply a list of interrupt line numbers.
     """
-    def __init__(self, cells: List[Any] = None):
+    def __init__(self, cells: List[Any]):
         """Create a CellArray object"""
         PropertyValues.__init__(self, cells)
 
@@ -86,7 +86,7 @@ class StringList(PropertyValues):
 
     The most common use of a StringList in Devicetree is to describe the `compatible` property.
     """
-    def __init__(self, strings: List[str] = None):
+    def __init__(self, strings: List[str]):
         """Create a StringList object"""
         PropertyValues.__init__(self, strings)
 

--- a/pydevicetree/ast/reference.py
+++ b/pydevicetree/ast/reference.py
@@ -51,6 +51,8 @@ class Path:
         if isinstance(other, Path):
             return self.to_dts() == other.to_dts()
         if isinstance(other, str):
+            if ("@" not in other) and (self.address is not None):
+                return self.to_dts().split("@")[0] == other
             return self.to_dts() == other
         return False
 

--- a/pydevicetree/ast/reference.py
+++ b/pydevicetree/ast/reference.py
@@ -20,7 +20,7 @@ class Label:
     def __repr__(self) -> str:
         return "<Label " + self.name + ">"
 
-    def __eq__(self, other: Union['Label', str]) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Label):
             return self.name == other.name
         if isinstance(other, str):
@@ -47,7 +47,7 @@ class Path:
     def __repr__(self) -> str:
         return "<Path " + self.to_dts() + ">"
 
-    def __eq__(self, other: Union['Path', str]) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Path):
             return self.to_dts() == other.to_dts()
         if isinstance(other, str):
@@ -72,6 +72,10 @@ class Reference:
 
     This is the parent class for both types of references, LabelReference and PathReference
     """
+    # pylint: disable=no-self-use
+    def to_dts(self) -> str:
+        """Format the Reference in Devicetree Source format"""
+        return ""
 
 class LabelReference(Reference):
     """A LabelReference is a reference to a Node by label"""

--- a/pydevicetree/source/grammar.py
+++ b/pydevicetree/source/grammar.py
@@ -20,9 +20,9 @@ node_path = p.Combine(p.Literal("/") + \
 path_reference = p.Literal("&{").suppress() + node_path + p.Literal("}").suppress()
 label_reference = p.Literal("&").suppress() + label
 reference = path_reference ^ label_reference
-directive = p.QuotedString(quoteChar="/", unquoteResults=False).setResultsName("directive") + \
+directive = p.QuotedString(quoteChar="/", unquoteResults=False) + \
         p.Optional(string ^ property_name ^ node_name ^ reference ^ \
-                (integer * 2)).setResultsName("option") + p.Literal(";").suppress()
+                (integer * 2)) + p.Literal(";").suppress()
 
 operator = p.oneOf("~ ! * / + - << >> < <= > >= == != & ^ | && ||")
 arith_expr = p.Forward()

--- a/pydevicetree/source/parser.py
+++ b/pydevicetree/source/parser.py
@@ -33,7 +33,9 @@ def transformPropertyAssignment(string, location, tokens):
 
 def transformDirective(string, location, tokens):
     """Transforms a ParseResult into a Directive"""
-    return Directive(tokens.directive, tokens.option)
+    if len(tokens.asList()) > 1:
+        return Directive(tokens[0], tokens[1])
+    return Directive(tokens[0])
 
 def evaluateArithExpr(string, location, tokens):
     """Evaluates a ParseResult as a python expression"""
@@ -153,10 +155,10 @@ def recurseIncludeFiles(elements, pwd):
         if isinstance(e, Directive):
             if e.directive == "/include/":
                 # Prefix with current directory if path is not absolute
-                if e.options[0] != '/':
-                    e.options = pwd + e.options
+                if e.option[0] != '/':
+                    e.option = pwd + e.option
 
-                with open(e.options, 'r') as f:
+                with open(e.option, 'r') as f:
                     contents = f.read()
 
                 elements += parseElements(contents)

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -30,6 +30,10 @@ class TestDevicetree(unittest.TestCase):
                     reg = <1>;
                 };
             };
+            memory@80000000 {
+                reg = <0x80000000 0x1000>;
+                reg-names = "mem";
+            };
             soc {
                 delete-property {
                     delete-me = "foo";
@@ -59,6 +63,10 @@ class TestDevicetree(unittest.TestCase):
         cpus = self.tree.get_by_path("/cpus")
         self.assertEqual(cpus.name, "cpus")
         self.assertEqual(len(cpus.children), 2)
+
+        # get node by path without address when unambiguous
+        memory = self.tree.get_by_path("/memory")
+        self.assertEqual(type(memory), Node)
 
     def test_delete_directive(self):
         soc = self.tree.get_by_path("/soc")

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -77,7 +77,7 @@ class TestGrammar(unittest.TestCase):
 
         self.assertEqual(type(dtsv1), Directive)
         self.assertEqual(dtsv1.directive, "/dts-v1/")
-        self.assertEqual(dtsv1.options, '')
+        self.assertEqual(dtsv1.option, None)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Run mypy on the pydevicetree module itself to discover some bad annotations which didn't get checked when running mypy -m unittest.

Also adds a test to make sure that we can get a node by path without specifying the address.