### PR TITLE
Add support for aliases

### DIFF
--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -382,6 +382,14 @@ class Devicetree(Node):
 
     def get_by_path(self, path: Union[Path, str]) -> Optional[Node]:
         """Get a node in the tree by path (ex. /cpus/cpu@0)"""
+
+        # Find and replace all aliases in the path
+        aliases = self.aliases()
+        if aliases:
+            for prop in aliases.properties:
+                if prop.name in path and len(prop.values) > 0:
+                    path = path.replace(prop.name, prop.values[0])
+
         return self.root().get_by_path(path)
 
     @staticmethod
@@ -412,6 +420,13 @@ class Devicetree(Node):
             if n.name == "/":
                 return n
         raise Exception("Devicetree has no root node!")
+
+    def aliases(self) -> Optional[Node]:
+        """Get the aliases node of the tree if it exists"""
+        for n in self.all_nodes():
+            if n.name == "aliases":
+                return n
+        return None
 
     def chosen(self, property_name: str, func: ChosenCallback = None) -> Optional[PropertyValues]:
         """Get the values associated with one of the properties in the chosen node"""

--- a/pydevicetree/ast/reference.py
+++ b/pydevicetree/ast/reference.py
@@ -59,6 +59,12 @@ class Path:
     def __iter__(self) -> Iterator[str]:
         return iter(['/'] + self.path)
 
+    def replace(self, old: str, new: str) -> 'Path':
+        """Replace any elements of the path which match 'old' with a new element 'new'"""
+        path = [e.replace(old, new) for e in self.path]
+        return Path('/' + '/'.join(path), self.address)
+
+
 class Reference:
     """A Reference is a Devicetree construct which points to a Node in the tree
 

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -14,6 +14,9 @@ class TestDevicetree(unittest.TestCase):
         / {
             #address-cells = <2>; // ignore this comment
             #size-cells = <2>;
+            aliases {
+                cpu-alias = "/cpus/cpu@1";
+            };
             chosen {
                 my-cpu = "/cpus/cpu@0";
             };
@@ -67,6 +70,15 @@ class TestDevicetree(unittest.TestCase):
         # get node by path without address when unambiguous
         memory = self.tree.get_by_path("/memory")
         self.assertEqual(type(memory), Node)
+
+        # aliases can be part of the path
+        cpu_alias = self.tree.get_by_path("cpu-alias")
+        self.assertEqual(type(cpu_alias), Node)
+        self.assertEqual(cpu_alias.get_field("reg"), 1)
+        # also test with a Path
+        cpu_alias = self.tree.get_by_path(Path("cpu-alias"))
+        self.assertEqual(type(cpu_alias), Node)
+        self.assertEqual(cpu_alias.get_field("reg"), 1)
 
     def test_delete_directive(self):
         soc = self.tree.get_by_path("/soc")


### PR DESCRIPTION
Devicetree aliases are shorthand for paths in the devicetree. This adds support for aliases so that if the tree defines them, Devicetree.get_by_path() will perform the substitution when searching for a node by path.