### PR TITLE
Create RegArray and RangeArray classes to encode the reg and ranges properties

### DIFF
--- a/pydevicetree/ast/__init__.py
+++ b/pydevicetree/ast/__init__.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2019 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-from pydevicetree.ast.property import PropertyValues, Bytestring, CellArray, StringList, Property
 from pydevicetree.ast.directive import Directive
 from pydevicetree.ast.node import Node, NodeReference, Devicetree
+from pydevicetree.ast.property import PropertyValues, Bytestring, CellArray, StringList, Property, \
+                                      RegArray
 from pydevicetree.ast.reference import Label, Path, Reference, LabelReference, PathReference

--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -288,24 +288,30 @@ class Node:
         return None
 
     def address_cells(self):
-        """Get the number of address cells"""
-        cells = self.get_field("#address-cells")
-        if cells is not None:
-            return cells
+        """Get the number of address cells
+
+        The #address-cells property is defined by the parent of a node and describes how addresses
+        are encoded in cell arrays. If no property is defined, the default value is 2.
+        """
         if self.parent is not None:
-            return self.parent.address_cells()
-        # No address cells found
-        return 0
+            cells = self.parent.get_field("#address-cells")
+            if cells is not None:
+                return cells
+            return 2
+        return 2
 
     def size_cells(self):
-        """Get the number of size cells"""
-        cells = self.get_field("#size-cells")
-        if cells is not None:
-            return cells
+        """Get the number of size cells
+
+        The #size-cells property is defined by the parent of a node and describes how addresses
+        are encoded in cell arrays. If no property is defined, the default value is 1.
+        """
         if self.parent is not None:
-            return self.parent.size_cells()
-        # No size cells found
-        return 0
+            cells = self.parent.get_field("#size-cells")
+            if cells is not None:
+                return cells
+            return 1
+        return 1
 
 class NodeReference(Node):
     """A NodeReference is used to extend the definition of a previously-defined Node

--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -7,7 +7,7 @@ import os
 from typing import List, Union, Optional, Iterable, Callable, Any, cast, Pattern
 
 from pydevicetree.ast.helpers import formatLevel
-from pydevicetree.ast.property import Property, PropertyValues
+from pydevicetree.ast.property import Property, PropertyValues, RegArray, RangeArray
 from pydevicetree.ast.directive import Directive
 from pydevicetree.ast.reference import Label, Path, Reference, LabelReference, PathReference
 
@@ -285,6 +285,24 @@ class Node:
         if fields is not None:
             if len(cast(PropertyValues, fields)) != 0:
                 return fields[0]
+        return None
+
+    def get_reg(self) -> Optional[RegArray]:
+        """If the node defines a `reg` property, return a RegArray for easier querying"""
+        reg = self.get_fields("reg")
+        reg_names = self.get_fields("reg-names")
+        if reg is not None:
+            if reg_names is not None:
+                return RegArray(reg.values, self.address_cells(), self.size_cells(),
+                                reg_names.values)
+            return RegArray(reg.values, self.address_cells(), self.size_cells())
+        return None
+
+    def get_ranges(self) -> Optional[RangeArray]:
+        """If the node defines a `ranges` property, return a RangeArray for easier querying"""
+        ranges = self.get_fields("ranges")
+        if ranges is not None:
+            return RangeArray(ranges.values, self.address_cells(), self.size_cells())
         return None
 
     def address_cells(self):

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -174,7 +174,34 @@ class TestDevicetree(unittest.TestCase):
         self.assertEqual(uart.name, "uart")
         self.assertEqual(uart.address, 0x10013000)
         self.assertEqual(uart.get_field("compatible"), "sifive,uart0")
-        
+
+    def test_reg_array(self):
+        spi_node = Node.from_dts("""spi@110013000 {
+            reg = <0x1 0x10013000 0x1000 0x0 0x20000000 0x10000000>;
+            reg-names = "control", "mem";
+        };""")
+
+        spi_reg = spi_node.get_reg()
+
+        control_reg = spi_reg.get_by_name("control")[0]
+        self.assertEqual(control_reg[0], 0x110013000)
+        self.assertEqual(control_reg[1], 0x1000)
+        mem_reg = spi_reg.get_by_name("mem")[0]
+        self.assertEqual(mem_reg[0], 0x20000000)
+        self.assertEqual(mem_reg[1], 0x10000000)
+
+    def test_ranges(self):
+        mem_node = Node.from_dts("""memory@180000000 {
+            device-type = "memory";
+            ranges = <0x1 0x80000000 0x1 0x80000000 0x80000000>;
+        };""")
+
+        mem_ranges = mem_node.get_ranges()
+
+        first_range = mem_ranges[0]
+        self.assertEqual(first_range[0], 0x180000000)
+        self.assertEqual(first_range[1], 0x180000000)
+        self.assertEqual(first_range[2], 0x80000000)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -12,8 +12,8 @@ class TestDevicetree(unittest.TestCase):
         /dts-v1/;
         /* ignore this comment */
         / {
-            #address-cells = <2>; // ignore this comment
-            #size-cells = <2>;
+            #address-cells = <1>; // ignore this comment
+            #size-cells = <1>;
             aliases {
                 cpu-alias = "/cpus/cpu@1";
             };
@@ -21,13 +21,13 @@ class TestDevicetree(unittest.TestCase):
                 my-cpu = "/cpus/cpu@0";
             };
             cpus {
+                #address-cells = <1>;
+                #size-cells = <0>;
                 cpu0: cpu@0 {
-                    #address-cells = <1>;
                     compatible = "riscv";
                     reg = <0>;
                 };
                 cpu@1 {
-                    #size-cells = <1>;
                     /* ignore this comment */
                     compatible = "riscv";
                     reg = <1>;
@@ -111,9 +111,9 @@ class TestDevicetree(unittest.TestCase):
         self.assertEqual(type(cpu1), Node)
 
         self.assertEqual(cpu0.address_cells(), 1)
-        self.assertEqual(cpu0.size_cells(), 2)
-        self.assertEqual(cpu1.address_cells(), 2)
-        self.assertEqual(cpu1.size_cells(), 1)
+        self.assertEqual(cpu0.size_cells(), 0)
+        self.assertEqual(cpu1.address_cells(), 1)
+        self.assertEqual(cpu1.size_cells(), 0)
 
     def test_filter(self):
         def matchFunc(n):


### PR DESCRIPTION
It's common to want to query nodes for their `reg` and `ranges` proprties to extract the fields by address and size. This allows the user to use `Node.get_reg()` and `Node.get_ranges()` to get the list of tuples from these properties.

These helpers automatically group cells of the `reg` and `ranges` properties by `#address-cells` and `#size-cells` and combine them into a single integer.