### PR TITLE
Fix interpretation of the `ranges` property

### DIFF
--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -301,8 +301,11 @@ class Node:
     def get_ranges(self) -> Optional[RangeArray]:
         """If the node defines a `ranges` property, return a RangeArray for easier querying"""
         ranges = self.get_fields("ranges")
+        child_address_cells = self.get_field("#address-cells")
+        parent_address_cells = self.address_cells()
+        size_cells = self.get_field("#size-cells")
         if ranges is not None:
-            return RangeArray(ranges.values, self.address_cells(), self.size_cells())
+            return RangeArray(ranges.values, child_address_cells, parent_address_cells, size_cells)
         return None
 
     def address_cells(self):

--- a/pydevicetree/ast/property.py
+++ b/pydevicetree/ast/property.py
@@ -139,17 +139,18 @@ class RegArray(CellArray):
 
 class RangeArray(CellArray):
     """A RangeArray is the CellArray assigned to the range property"""
-    def __init__(self, cells: List[int],
-                 address_cells: int, size_cells: int):
+    def __init__(self, cells: List[int], child_address_cells: int,
+                 parent_address_cells: int, size_cells: int):
         """Create a RangeArray from a list of ints"""
         # pylint: disable=too-many-locals
         CellArray.__init__(self, cells)
-        self.address_cells = address_cells
+        self.child_address_cells = child_address_cells
+        self.parent_address_cells = parent_address_cells
         self.size_cells = size_cells
 
         self.tuples = [] # type: List[Tuple[int, int, int]]
 
-        group_size = 2 * self.address_cells + self.size_cells
+        group_size = self.child_address_cells + self.parent_address_cells + self.size_cells
 
         if len(cells) % group_size != 0:
             raise Exception("CellArray does not not contain enough cells")
@@ -163,12 +164,13 @@ class RangeArray(CellArray):
             return value
 
         for group in grouped_cells:
-            parent_address = sum_cells(group[:self.address_cells])
-            child_address = sum_cells(group[self.address_cells:2*self.address_cells])
-            size = sum_cells(group[2*self.address_cells:])
+            child_address = sum_cells(group[:self.child_address_cells])
+            parent_address = sum_cells(group[self.child_address_cells: \
+                                             self.child_address_cells + self.parent_address_cells])
+            size = sum_cells(group[self.child_address_cells + self.parent_address_cells:])
 
             self.tuples.append(cast(Tuple[int, int, int],
-                                    tuple([parent_address, child_address, size])))
+                                    tuple([child_address, parent_address, size])))
 
     def __repr__(self) -> str:
         return "<RangeArray " + self.values.__repr__() + ">"

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -12,8 +12,8 @@ class TestDevicetree(unittest.TestCase):
         /dts-v1/;
         /* ignore this comment */
         / {
-            #address-cells = <1>; // ignore this comment
-            #size-cells = <1>;
+            #address-cells = <2>; // ignore this comment
+            #size-cells = <2>;
             aliases {
                 cpu-alias = "/cpus/cpu@1";
             };
@@ -33,9 +33,11 @@ class TestDevicetree(unittest.TestCase):
                     reg = <1>;
                 };
             };
-            memory@80000000 {
-                reg = <0x80000000 0x1000>;
-                reg-names = "mem";
+            memory@180000000 {
+                #address-cells = <2>;
+                #size-cells = <1>;
+                device-type = "memory";
+                ranges = <0x1 0x80000000 0x1 0x80000000 0x1000>;
             };
             soc {
                 delete-property {
@@ -191,17 +193,13 @@ class TestDevicetree(unittest.TestCase):
         self.assertEqual(mem_reg[1], 0x10000000)
 
     def test_ranges(self):
-        mem_node = Node.from_dts("""memory@180000000 {
-            device-type = "memory";
-            ranges = <0x1 0x80000000 0x1 0x80000000 0x80000000>;
-        };""")
-
+        mem_node = self.tree.get_by_path("/memory")
         mem_ranges = mem_node.get_ranges()
 
         first_range = mem_ranges[0]
         self.assertEqual(first_range[0], 0x180000000)
         self.assertEqual(first_range[1], 0x180000000)
-        self.assertEqual(first_range[2], 0x80000000)
+        self.assertEqual(first_range[2], 0x1000)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I was wrong about my interpretation of the `ranges` property, and so the
implementation of `Node.get_ranges()` was wrong.

The ranges property is encoded according to the following properties:
 - #address-cells of the bus -> the number of cells for the child
   address
 - #address-cells of the bus's parent -> the number of cells for the
   parent address
 - #size-cells of the bus -> the number of cells for the size

I had also switched the order of the parent address and child address.

All of this is now taken into account with this patch.