### PR TITLE
Fixes to includes and include directives

### DIFF
--- a/pydevicetree/ast/directive.py
+++ b/pydevicetree/ast/directive.py
@@ -4,7 +4,7 @@
 
 from typing import Any
 
-from pydevicetree.ast.helpers import formatLevel
+from pydevicetree.ast.helpers import formatLevel, wrapStrings
 
 class Directive:
     """Represents a Devicetree directive
@@ -36,6 +36,11 @@ class Directive:
 
     def to_dts(self, level: int = 0) -> str:
         """Format the Directive in Devicetree Source format"""
-        if self.option:
-            return formatLevel(level, "%s %s;\n" % (self.directive, self.option))
+        if isinstance(self.option, list):
+            return formatLevel(level, "%s %s;\n" % (self.directive,
+                                                    wrapStrings(self.option)))
+        if isinstance(self.option, str):
+            if self.directive == "/include/":
+                return formatLevel(level, "%s \"%s\"\n" % (self.directive, self.option))
+            return formatLevel(level, "%s \"%s\";\n" % (self.directive, self.option))
         return formatLevel(level, "%s;\n" % self.directive)

--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -460,8 +460,10 @@ class Devicetree(Node):
         from pydevicetree.source import parseTree
         with open(filename, 'r') as f:
             contents = f.read()
-        pwd = os.path.dirname(filename) + "/"
-        return parseTree(contents, pwd, followIncludes)
+        dirname = os.path.dirname(filename)
+        if dirname != "":
+            dirname += "/"
+        return parseTree(contents, dirname, followIncludes)
 
     def all_nodes(self) -> Iterable[Node]:
         """Get an iterable over all nodes in the tree"""

--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -403,8 +403,9 @@ class Devicetree(Node):
         for node in self.children:
             node.parent = self
 
-        reference_nodes = filter(lambda node: isinstance(node, NodeReference), self.all_nodes())
-        for refnode in cast(List[NodeReference], reference_nodes):
+        reference_nodes = self.filter(lambda n: isinstance(n, NodeReference))
+        for refnode in reference_nodes:
+            refnode = cast(NodeReference, refnode)
             node = refnode.resolve_reference(self)
 
             if refnode.parent:

--- a/pydevicetree/source/grammar.py
+++ b/pydevicetree/source/grammar.py
@@ -20,9 +20,11 @@ node_path = p.Combine(p.Literal("/") + \
 path_reference = p.Literal("&{").suppress() + node_path + p.Literal("}").suppress()
 label_reference = p.Literal("&").suppress() + label
 reference = path_reference ^ label_reference
-directive = p.QuotedString(quoteChar="/", unquoteResults=False) + \
-        p.Optional(string ^ property_name ^ node_name ^ reference ^ \
-                (integer * 2)) + p.Literal(";").suppress()
+include_directive = p.Literal("/include/") + p.QuotedString(quoteChar='"')
+generic_directive = p.QuotedString(quoteChar="/", unquoteResults=False) + \
+        p.Optional(string ^ property_name ^ node_name ^ reference ^ (integer * 2)) + \
+        p.Literal(";").suppress()
+directive = include_directive ^ generic_directive
 
 operator = p.oneOf("~ ! * / + - << >> < <= > >= == != & ^ | && ||")
 arith_expr = p.Forward()

--- a/pydevicetree/source/parser.py
+++ b/pydevicetree/source/parser.py
@@ -163,6 +163,8 @@ def recurseIncludeFiles(elements, pwd):
 
                 elements += parseElements(contents)
 
+                del elements[elements.asList().index(e)]
+
 def parseElements(dts, pwd="", followIncludes=False):
     """Parses a string into a list of elements"""
     elements = grammar.devicetree.parseString(dts, parseAll=True)

--- a/tests/devicetrees/include/base.dts
+++ b/tests/devicetrees/include/base.dts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 /dts-v1/;
 
-/include/ "overlay.dtsi";
+/include/ "overlay.dtsi"
 
 / {
 	#address-cells = <1>;

--- a/tests/test_devicetree.py
+++ b/tests/test_devicetree.py
@@ -91,6 +91,10 @@ class TestDevicetree(unittest.TestCase):
         self.assertEqual(type(delete_property), Node)
         self.assertEqual(delete_property.get_field("delete-me"), None)
 
+    def test_include_directive(self):
+        tree = Devicetree.from_dts("/include/ \"foo.dtsi\"")
+        self.assertEqual(tree.directives[0].to_dts(), "/include/ \"foo.dtsi\"\n")
+
     def test_get_by_label(self):
         cpu0 = self.tree.get_by_label("cpu0")
         self.assertEqual(cpu0.name, "cpu")


### PR DESCRIPTION
* The Devicetree spec does not have a trailing semicolon on include directives
* Strings in directives are wrapped in quotes
* Multiple NodeReferences are all resolved
* Followed include directives are removed