### PR TITLE
Test against latest dependencies in CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,3 @@
-astroid==2.3.2
-isort==4.3.21
-lazy-object-proxy==1.4.3
-mccabe==0.6.1
-mypy==0.740
-mypy-extensions==0.4.3
-pylint==2.4.3
-pyparsing==2.4.2
-six==1.12.0
-typed-ast==1.4.0
-typing-extensions==3.7.4.1
-wrapt==1.11.2
+mypy
+pylint
+pyparsing


### PR DESCRIPTION
Users installing the package will pull the latest versions of pyparsing and mypy, so we should test against the latest versions in CI.