### PR TITLE
Add HiFive board Devicetrees to integration tests

### DIFF
--- a/pydevicetree/ast/property.py
+++ b/pydevicetree/ast/property.py
@@ -34,7 +34,7 @@ class PropertyValues:
 
     def to_dts(self, formatHex: bool = False) -> str:
         """Format the values in Devicetree Source format"""
-        return " ".join(wrapStrings(self.values, formatHex))
+        return ", ".join(wrapStrings(self.values, formatHex))
 
     def __getitem__(self, key) -> Any:
         return self.values[key]

--- a/pydevicetree/ast/reference.py
+++ b/pydevicetree/ast/reference.py
@@ -74,7 +74,7 @@ class Reference:
     This is the parent class for both types of references, LabelReference and PathReference
     """
     # pylint: disable=no-self-use
-    def to_dts(self) -> str:
+    def to_dts(self, formatHex: bool = False) -> str:
         """Format the Reference in Devicetree Source format"""
         return ""
 
@@ -90,7 +90,7 @@ class LabelReference(Reference):
     def __repr__(self) -> str:
         return "<LabelReference " + self.to_dts() + ">"
 
-    def to_dts(self) -> str:
+    def to_dts(self, formatHex: bool = False) -> str:
         """Format the LabelReference in Devicetree Source format"""
         return "&" + self.label.name
 
@@ -106,6 +106,6 @@ class PathReference(Reference):
     def __repr__(self) -> str:
         return "<PathReference " + self.to_dts() + ">"
 
-    def to_dts(self) -> str:
+    def to_dts(self, formatHex: bool = False) -> str:
         """Format the PathReference in Devicetree Source format"""
         return "&{" + self.path.to_dts() + "}"

--- a/pydevicetree/source/grammar.py
+++ b/pydevicetree/source/grammar.py
@@ -39,7 +39,8 @@ bytestring = p.Literal("[").suppress() + \
         (p.OneOrMore(p.Word(p.hexnums, exact=2) ^ label_creation.suppress())) + \
         p.Literal("]").suppress()
 property_values = p.Forward()
-property_values = p.delimitedList(property_values ^ cell_array ^ bytestring ^ stringlist)
+property_values = p.delimitedList(property_values ^ cell_array ^ bytestring ^ stringlist ^ \
+                                  reference)
 property_assignment = property_name("property_name") + p.Optional(p.Literal("=").suppress() + \
         (property_values)).setResultsName("value") + p.Literal(";").suppress()
 

--- a/pydevicetree/source/parser.py
+++ b/pydevicetree/source/parser.py
@@ -28,6 +28,8 @@ def transformPropertyAssignment(string, location, tokens):
             return Property(tokens.property_name, v)
         if isinstance(v, StringList):
             return Property(tokens.property_name, v)
+        if isinstance(v, Reference):
+            return Property(tokens.property_name, v)
 
     return Property(tokens.property_name, PropertyValues([]))
 

--- a/tests/devicetrees/sifive/hifive-unleashed.dts
+++ b/tests/devicetrees/sifive/hifive-unleashed.dts
@@ -1,0 +1,509 @@
+/dts-v1/;
+/ {
+	#address-cells = <2>;
+	#size-cells = <2>;
+	compatible = "sifive,fu540g", "sifive,fu500";
+	model = "sifive,hifive-unleashed-a00";
+	aliases {
+		serial0 = &L28;
+		serial1 = &L29;
+	};
+	firmware {
+		sifive,fsbl = "YYYY-MM-DD";
+	};
+	L3: cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		timebase-frequency = <1000000>;
+		L9: cpu@0 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <128>;
+			i-cache-size = <16384>;
+			next-level-cache = <&L24 &L0>;
+			reg = <0x0>;
+			riscv,isa = "rv64imac";
+			riscv,pmpregions = <8>;
+			sifive,dtim = <&L8>;
+			sifive,itim = <&L7>;
+			status = "okay";
+			L10: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L12: cpu@1 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <0x1>;
+			riscv,isa = "rv64imafdc";
+			riscv,pmpregions = <8>;
+			sifive,itim = <&L11>;
+			status = "okay";
+			tlb-split;
+			L13: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L15: cpu@2 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <0x2>;
+			riscv,isa = "rv64imafdc";
+			riscv,pmpregions = <8>;
+			sifive,itim = <&L14>;
+			status = "okay";
+			tlb-split;
+			L16: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L18: cpu@3 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <0x3>;
+			riscv,isa = "rv64imafdc";
+			riscv,pmpregions = <8>;
+			sifive,itim = <&L17>;
+			status = "okay";
+			tlb-split;
+			L19: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+		L21: cpu@4 {
+			clock-frequency = <0>;
+			compatible = "sifive,rocket0", "riscv";
+			d-cache-block-size = <64>;
+			d-cache-sets = <64>;
+			d-cache-size = <32768>;
+			d-tlb-sets = <1>;
+			d-tlb-size = <32>;
+			device_type = "cpu";
+			i-cache-block-size = <64>;
+			i-cache-sets = <64>;
+			i-cache-size = <32768>;
+			i-tlb-sets = <1>;
+			i-tlb-size = <32>;
+			mmu-type = "riscv,sv39";
+			next-level-cache = <&L24 &L0>;
+			reg = <0x4>;
+			riscv,isa = "rv64imafdc";
+			riscv,pmpregions = <8>;
+			sifive,itim = <&L20>;
+			status = "okay";
+			tlb-split;
+			L22: interrupt-controller {
+				#interrupt-cells = <1>;
+				compatible = "riscv,cpu-intc";
+				interrupt-controller;
+			};
+		};
+	};
+	L36: memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x1f 0x80000000>;
+	};
+	L2: soc {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		compatible = "SiFive,FU540G-soc", "fu500-soc", "sifive-soc", "simple-bus";
+		ranges;
+		refclk: refclk {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <33333333>;
+			clock-output-names = "xtal";
+		};
+		prci: prci@10000000 {
+			compatible = "sifive,ux00prci0";
+			reg = <0x0 0x10000000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&refclk>;
+			#clock-cells = <1>;
+		};
+		tlclk: tlclk {
+			compatible = "fixed-factor-clock";
+			clocks = <&refclk>;
+			#clock-cells = <0>;
+			clock-div = <2>;
+			clock-mult = <1>;
+		};
+		L51: cadence-gemgxl-mgmt@100a0000 {
+			compatible = "sifive,cadencegemgxlmgmt0";
+			reg = <0x0 0x100a0000 0x0 0x1000>;
+			reg-names = "control";
+			#clock-cells = <0>;
+		};
+		L35: bus-blocker@100b8000 {
+			compatible = "sifive,bus-blocker0";
+			reg = <0x0 0x100b8000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L0: cache-controller@2010000 {
+			cache-block-size = <64>;
+			cache-level = <2>;
+			cache-sets = <2048>;
+			cache-size = <2097152>;
+			cache-unified;
+			compatible = "sifive,fu540-c000,l2", "cache";
+			interrupt-parent = <&L4>;
+			interrupts = <1 2 3>;
+			next-level-cache = <&L25 &L40 &L36>;
+			reg = <0x0 0x2010000 0x0 0x1000 0x0 0x8000000 0x0 0x2000000>;
+			reg-names = "control", "sideband";
+		};
+		L33: cadence-ddr-mgmt@100c0000 {
+			compatible = "sifive,cadenceddrmgmt0";
+			reg = <0x0 0x100c0000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L40: chiplink@40000000 {
+			#address-cells = <2>;
+			#size-cells = <2>;
+			compatible = "sifive,chiplink", "simple-bus";
+			ranges = <0x0 0x60000000 0x0 0x60000000 0x0 0x20000000 0x30 0x0 0x30 0x0 0x10 0x0 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000 0x20 0x0 0x20 0x0 0x10 0x0>;
+		};
+		L5: clint@2000000 {
+			compatible = "riscv,clint0";
+			interrupts-extended = <&L10 3 &L10 7 &L13 3 &L13 7 &L16 3 &L16 7 &L19 3 &L19 7 &L22 3 &L22 7>;
+			reg = <0x0 0x2000000 0x0 0x10000>;
+			reg-names = "control";
+		};
+		L6: debug-controller@0 {
+			compatible = "sifive,debug-013", "riscv,debug-013";
+			interrupts-extended = <&L10 65535 &L13 65535 &L16 65535 &L19 65535 &L22 65535>;
+			reg = <0x0 0x0 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L32: dma@3000000 {
+			#dma-cells = <1>;
+			compatible = "riscv,dma0";
+			dma-channels = <4>;
+			dma-requests = <0>;
+			interrupt-parent = <&L4>;
+			interrupts = <23 24 25 26 27 28 29 30>;
+			reg = <0x0 0x3000000 0x0 0x100000>;
+			reg-names = "control";
+			riscv,dma-pools = <1>;
+		};
+		L8: dtim@1000000 {
+			compatible = "sifive,dtim0";
+			reg = <0x0 0x1000000 0x0 0x2000>;
+			reg-names = "mem";
+		};
+		L44: ememoryotp@10070000 {
+			compatible = "sifive,ememoryotp0";
+			reg = <0x0 0x10070000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L24: error-device@18000000 {
+			compatible = "sifive,error0";
+			reg = <0x0 0x18000000 0x0 0x8000000>;
+			reg-names = "mem";
+		};
+		L52: ethernet@10090000 {
+			compatible = "cdns,macb";
+			interrupt-parent = <&L4>;
+			interrupts = <53>;
+			reg = <0x0 0x10090000 0x0 0x2000>;
+			reg-names = "control";
+
+			local-mac-address = [00 00 00 00 00 00];
+			phy-mode = "gmii";
+			clock-names = "pclk", "hclk", "tx_clk";
+			clocks = <&prci 1>, <&prci 1>, <&L51>;
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+			phy1: ethernet-phy@0 {
+				reg = <0x0>;
+				reset-gpios = <&L31 12 1>;
+			};
+		};
+		L31: gpio@10060000 {
+			compatible = "sifive,gpio0";
+			interrupt-parent = <&L4>;
+			interrupts = <7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22>;
+			reg = <0x0 0x10060000 0x0 0x1000>;
+			reg-names = "control";
+			gpio-controller;
+			#gpio-cells = <2>;
+			interrupt-controller;
+			#interrupt-cells = <2>;
+		};
+		gpio-restart {
+			compatible = "gpio-restart";
+			gpios = <&L31 10 1>;
+		};
+		L47: i2c@10030000 {
+			compatible = "sifive,i2c0", "opencores,i2c-ocores";
+			reg = <0x0 0x10030000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+			reg-shift = <2>;
+			reg-io-width = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		L4: interrupt-controller@c000000 {
+			#interrupt-cells = <1>;
+			compatible = "riscv,plic0";
+			interrupt-controller;
+			interrupts-extended = <&L10 11 &L13 11 &L13 9 &L16 11 &L16 9 &L19 11 &L19 9 &L22 11 &L22 9>;
+			reg = <0x0 0xc000000 0x0 0x4000000>;
+			reg-names = "control";
+			riscv,max-priority = <7>;
+			riscv,ndev = <53>;
+		};
+		L7: itim@1800000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1800000 0x0 0x4000>;
+			reg-names = "mem";
+		};
+		L11: itim@1808000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1808000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L14: itim@1810000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1810000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L17: itim@1818000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1818000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L20: itim@1820000 {
+			compatible = "sifive,itim0";
+			reg = <0x0 0x1820000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L37: memory-controller@100b0000 {
+			compatible = "sifive,ux00ddr0";
+			interrupt-parent = <&L4>;
+			interrupts = <31>;
+			reg = <0x0 0x100b0000 0x0 0x4000>;
+			reg-names = "control";
+		};
+		pci@2000000000 {
+			#address-cells = <3>;
+			#interrupt-cells = <1>;
+			#size-cells = <2>;
+			compatible = "xlnx,axi-pcie-host-1.00.a";
+			device_type = "pci";
+			interrupt-map = <0 0 0 1 &xil_pcie_intc 1 0 0 0 2 &xil_pcie_intc 2 0 0 0 3 &xil_pcie_intc 3 0 0 0 4 &xil_pcie_intc 4>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-parent = <&L4>;
+			interrupts = <32>;
+			ranges = <0x2000000 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000>;
+			reg = <0x20 0x0 0x0 0x4000000>;
+			reg-names = "control";
+			xil_pcie_intc: interrupt-controller {
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		pci@2030000000 {
+			#address-cells = <3>;
+			#interrupt-cells = <1>;
+			#size-cells = <2>;
+			compatible = "ms-pf,axi-pcie-host";
+			device_type = "pci";
+			bus-range = <1 127>;
+			interrupt-map = <0 0 0 1 &ms_pcie_intc 1 0 0 0 2 &ms_pcie_intc 2 0 0 0 3 &ms_pcie_intc 3 0 0 0 4 &ms_pcie_intc 4>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-parent = <&L4>;
+			interrupts = <32>;
+			ranges = <0x2000000 0x0 0x40000000 0x0 0x40000000 0x0 0x20000000>;
+			reg = <0x20 0x30000000 0x0 0x4000000 0x20 0x0 0x0 0x100000>;
+			reg-names = "control", "apb";
+			ms_pcie_intc: interrupt-controller {
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		L53: pinctrl@10080000 {
+			compatible = "sifive,pinctrl0";
+			reg = <0x0 0x10080000 0x0 0x1000>;
+			reg-names = "control";
+		};
+		L45: pwm@10020000 {
+			compatible = "sifive,pwm0";
+			interrupt-parent = <&L4>;
+			interrupts = <42 43 44 45>;
+			reg = <0x0 0x10020000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+			sifive,approx-period = <1000000>;
+			#pwm-cells = <2>;
+		};
+		L46: pwm@10021000 {
+			compatible = "sifive,pwm0";
+			interrupt-parent = <&L4>;
+			interrupts = <46 47 48 49>;
+			reg = <0x0 0x10021000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+			sifive,approx-period = <1000000>;
+			#pwm-cells = <2>;
+		};
+		pwmleds {
+			compatible = "pwm-leds";
+			heartbeat {
+				pwms = <&L45 0 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "heartbeat";
+			};
+			mtd {
+				pwms = <&L45 1 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "mtd";
+			};
+			netdev {
+				pwms = <&L45 2 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "netdev";
+			};
+			panic {
+				pwms = <&L45 3 0>;
+				max-brightness = <255>;
+				linux,default-trigger = "panic";
+			};
+		};
+		L27: rom@1000 {
+			compatible = "sifive,modeselect0";
+			reg = <0x0 0x1000 0x0 0x1000>;
+			reg-names = "mem";
+		};
+		L26: rom@10000 {
+			compatible = "sifive,maskrom0";
+			reg = <0x0 0x10000 0x0 0x8000>;
+			reg-names = "mem";
+		};
+		L25: rom@a000000 {
+			compatible = "ucbbar,cacheable-zero0";
+			reg = <0x0 0xa000000 0x0 0x2000000>;
+			reg-names = "mem";
+		};
+		L28: serial@10010000 {
+			compatible = "sifive,uart0";
+			interrupt-parent = <&L4>;
+			interrupts = <4>;
+			reg = <0x0 0x10010000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+		};
+		L29: serial@10011000 {
+			compatible = "sifive,uart0";
+			interrupt-parent = <&L4>;
+			interrupts = <5>;
+			reg = <0x0 0x10011000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+		};
+		L49: spi@10040000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L4>;
+			interrupts = <51>;
+			reg = <0x0 0x10040000 0x0 0x1000 0x0 0x20000000 0x0 0x10000000>;
+			reg-names = "control", "mem";
+			clocks = <&tlclk>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			flash@0 {
+				compatible = "issi,is25wp256d", "jedec,spi-nor";
+				reg = <0x0>;
+				spi-max-frequency = <50000000>;
+				m25p,fast-read;
+				spi-tx-bus-width = <4>;
+				spi-rx-bus-width = <4>;
+			};
+		};
+		L50: spi@10041000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L4>;
+			interrupts = <52>;
+			reg = <0x0 0x10041000 0x0 0x1000 0x0 0x30000000 0x0 0x10000000>;
+			reg-names = "control", "mem";
+			clocks = <&tlclk>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+		L30: spi@10050000 {
+			compatible = "sifive,spi0";
+			interrupt-parent = <&L4>;
+			interrupts = <6>;
+			reg = <0x0 0x10050000 0x0 0x1000>;
+			reg-names = "control";
+			clocks = <&tlclk>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			mmc@0 {
+				compatible = "mmc-spi-slot";
+				reg = <0x0>;
+				spi-max-frequency = <20000000>;
+				voltage-ranges = <3300 3300>;
+				disable-wp;
+				gpios = <&L31 11 1>;
+			};
+		};
+		L23: teststatus@4000 {
+			compatible = "sifive,test0";
+			reg = <0x0 0x4000 0x0 0x1000>;
+			reg-names = "control";
+		};
+	};
+};

--- a/tests/devicetrees/sifive/hifive1-revb.dts
+++ b/tests/devicetrees/sifive/hifive1-revb.dts
@@ -1,0 +1,250 @@
+/dts-v1/;
+/ {
+        #address-cells = <1>;
+        #size-cells = <1>;
+        compatible = "sifive,hifive1-revb";
+        model = "sifive,hifive1-revb";
+        cpus {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                compatible = "sifive,fe310-g000";
+                L6: cpu@0 {
+                        clocks = <&hfclk>;
+                        compatible = "sifive,rocket0", "riscv";
+                        device_type = "cpu";
+                        i-cache-block-size = <64>;
+                        i-cache-sets = <128>;
+                        i-cache-size = <16384>;
+                        next-level-cache = <&spi0>;
+                        reg = <0x0>;
+                        riscv,isa = "rv32imac";
+                        riscv,pmpregions = <8>;
+                        sifive,itim = <&itim>;
+                        sifive,dtim = <&dtim>;
+                        status = "okay";
+                        timebase-frequency = <16000000>;
+                        hardware-exec-breakpoint-count = <4>;
+                        hlic: interrupt-controller {
+                                #interrupt-cells = <1>;
+                                compatible = "riscv,cpu-intc";
+                                interrupt-controller;
+                        };
+                };
+        };
+        soc {
+                #address-cells = <1>;
+                #size-cells = <1>;
+                #clock-cells = <1>;
+                compatible = "sifive,hifive1";
+                ranges;
+                hfxoscin: clock@0 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <16000000>;
+                };
+                hfxoscout: clock@1 {
+                        compatible = "sifive,fe310-g000,hfxosc";
+                        clocks = <&hfxoscin>;
+                        reg = <&prci 0x4>;
+                        reg-names = "config";
+                };
+                hfroscin: clock@2 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <72000000>;
+                };
+                hfroscout: clock@3 {
+                        compatible = "sifive,fe310-g000,hfrosc";
+                        clocks = <&hfroscin>;
+                        reg = <&prci 0x0>;
+                        reg-names = "config";
+                };
+                hfclk: clock@4 {
+                        compatible = "sifive,fe310-g000,pll";
+                        clocks = <&hfxoscout &hfroscout>;
+                        clock-names = "pllref", "pllsel0";
+                        reg = <&prci 0x8 &prci 0xc>;
+                        reg-names = "config", "divider";
+			clock-frequency = <16000000>;
+                };
+                lfrosc: clock@5 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <32768>;
+                };
+                psdlfaltclk: clock@6 {
+                        #clock-cells = <0>;
+                        compatible = "fixed-clock";
+                        clock-frequency = <32768>;
+                };
+                lfclk: clock@7 {
+                        compatible = "sifive,fe310-g000,lfrosc";
+                        clocks = <&lfrosc &psdlfaltclk>;
+                        clock-names = "lfrosc", "psdlfaltclk";
+                        reg = <&aon 0x70 &aon 0x7c>;
+                        reg-names = "config", "mux";
+                };
+                debug-controller@0 {
+                        compatible = "sifive,debug-011", "riscv,debug-011";
+                        interrupts-extended = <&hlic 65535>;
+                        reg = <0x0 0x1000>;
+                        reg-names = "control";
+                };
+                maskrom@1000 {
+                        reg = <0x1000 0x2000>;
+                        reg-names = "mem";
+                };
+                otp@20000 {
+                        reg = <0x20000 0x2000 0x10010000 0x1000>;
+                        reg-names = "mem", "control";
+                };
+                clint: clint@2000000 {
+                        compatible = "riscv,clint0";
+                        interrupts-extended = <&hlic 3 &hlic 7>;
+                        reg = <0x2000000 0x10000>;
+                        reg-names = "control";
+                };
+                itim: itim@8000000 {
+                        compatible = "sifive,itim0";
+                        reg = <0x8000000 0x2000>;
+                        reg-names = "mem";
+                };
+                plic: interrupt-controller@c000000 {
+                        #interrupt-cells = <1>;
+                        compatible = "riscv,plic0";
+                        interrupt-controller;
+                        interrupts-extended = <&hlic 11>;
+                        reg = <0xc000000 0x4000000>;
+                        reg-names = "control";
+                        riscv,max-priority = <7>;
+                        riscv,ndev = <52>;
+                };
+                aon: aon@10000000 {
+                        compatible = "sifive,aon0";
+                        reg = <0x10000000 0x8000>;
+                        reg-names = "mem";
+                        interrupt-parent = <&plic>;
+                        interrupts = <1 2>;
+                        clocks = <&lfclk>;
+                };
+                prci: prci@10008000 {
+                        compatible = "sifive,fe310-g000,prci";
+                        reg = <0x10008000 0x8000>;
+                        reg-names = "mem";
+                };
+                gpio0: gpio@10012000 {
+                        compatible = "sifive,gpio0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 27 28 29>;
+                        reg = <0x10012000 0x1000>;
+                        reg-names = "control";
+                };
+                led@0 {
+                        compatible = "sifive,gpio-leds";
+                        label = "LD0red";
+                        gpios = <&gpio0 22>;
+                        linux,default-trigger = "none";
+                };
+                led@1 {
+                        compatible = "sifive,gpio-leds";
+                        label = "LD0green";
+                        gpios = <&gpio0 19>;
+                        linux,default-trigger = "none";
+                };
+                led@2 {
+                        compatible = "sifive,gpio-leds";
+                        label = "LD0blue";
+                        gpios = <&gpio0 21>;
+                        linux,default-trigger = "none";
+                };
+                uart0: serial@10013000 {
+                        compatible = "sifive,uart0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <3>;
+                        reg = <0x10013000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                        pinmux = <&gpio0 196608 196608>;
+                };
+                spi0: spi@10014000 {
+                        compatible = "sifive,spi0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <5>;
+                        reg = <0x10014000 0x1000 0x20000000 0x20000000>;
+                        reg-names = "control", "mem";
+                        clocks = <&hfclk>;
+                        pinmux = <&gpio0 0 0>;
+                        #address-cells = <1>;
+                        #size-cells = <1>;
+                        flash@0 {
+                                compatible = "jedec,spi-nor";
+                                reg = <0x20000000 0x424000>;
+                        };
+                };
+                pwm0: pwm@10015000 {
+                        compatible = "sifive,pwm0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <40 41 42 43>;
+                        reg = <0x10015000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                };
+                i2c0: i2c@10016000 {
+                        compatible = "sifive,i2c0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <52>;
+                        reg = <0x10016000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                        pinmux = <&gpio0 12288 12288>;
+                };
+                uart1: serial@10023000 {
+                        compatible = "sifive,uart0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <4>;
+                        reg = <0x10023000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                        pinmux = <&gpio0 8650752 8650752>;
+                };
+                spi1: spi@10024000 {
+                        compatible = "sifive,spi0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <6>;
+                        reg = <0x10024000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                        pinmux = <&gpio0 60 60>;
+                };
+                pwm1: pwm@10025000 {
+                        compatible = "sifive,pwm0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <44 45 46 47>;
+                        reg = <0x10025000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                };
+                spi2: spi@10034000 {
+                        compatible = "sifive,spi0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <7>;
+                        reg = <0x10034000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                        pinmux = <&gpio0 4227858432 4227858432>;
+                };
+                pwm2: pwm@10035000 {
+                        compatible = "sifive,pwm0";
+                        interrupt-parent = <&plic>;
+                        interrupts = <48 49 50 51>;
+                        reg = <0x10035000 0x1000>;
+                        reg-names = "control";
+                        clocks = <&hfclk>;
+                };
+                dtim: dtim@80000000 {
+                        compatible = "sifive,dtim0";
+                        reg = <0x80000000 0x4000>;
+                        reg-names = "mem";
+                };
+        };
+};


### PR DESCRIPTION
Adds the Devicetrees for the HiFive1 RevB and the HiFive Unleashed.

Fixes two bugs:
1. Properties can be assigned a reference without the reference being in an cell array
2. PropertyValues are formatted with commas between their elements