### PR TITLE
Make sure new children are reparented when merging

### DIFF
--- a/pydevicetree/ast/node.py
+++ b/pydevicetree/ast/node.py
@@ -162,6 +162,7 @@ class Node:
         self.children = new_children
 
         for n in self.children:
+            n.parent = self
             n.merge_tree()
 
     def merge(self, other: 'Node'):


### PR DESCRIPTION
NodeReferences failed to have their parents properly set when merging trees. This makes sure that all new children of a node have their parent set to that node.