### PR TITLE
Remove bound on parser memoization cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run unit tests
         run:
           make test-unit
+      - name: Run unit tests with bounded parser cache
+        run:
+          make test-cache-size-bound
       - name: Run integration tests
         run:
           make test-integration

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ test-unit: venv/bin/activate $(UNIT_TESTS)
 	. $< && python3 -m unittest $(UNIT_TESTS)
 test: test-unit
 
+.PHONY: test-cache-size-bound
+test-cache-size-bound: venv/bin/activate $(UNIT_TESTS)
+	PYDEVICETREE_CACHE_SIZE_BOUND=128 . $< && python3 -m unittest $(UNIT_TESTS)
+test: test-cache-size-bound
+
 INTEGRATION_TESTS = tests/test_full_trees.py
 
 .PHONY: test-integration

--- a/pydevicetree/source/grammar.py
+++ b/pydevicetree/source/grammar.py
@@ -2,9 +2,22 @@
 # Copyright (c) 2019 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
+
 import pyparsing as p # type: ignore
 
-p.ParserElement.enablePackrat()
+ENV_CACHE_OPTION = "PYDEVICETREE_CACHE_SIZE_BOUND"
+
+cache_bound = None
+if ENV_CACHE_OPTION in os.environ:
+    option = os.environ[ENV_CACHE_OPTION]
+    if option != "None":
+        try:
+            cache_bound = int(option)
+        except ValueError:
+            print("%s requires a valid integer" % ENV_CACHE_OPTION, file=sys.stderr)
+p.ParserElement.enablePackrat(cache_bound)
 
 node_name = p.Word(p.alphanums + ",.-+_") ^ p.Literal("/")
 integer = p.pyparsing_common.integer ^ (p.Literal("0x").suppress() + p.pyparsing_common.hex_integer)
@@ -59,6 +72,5 @@ devicetree.ignore(p.cStyleComment)
 devicetree.ignore("//" + p.SkipTo(p.lineEnd))
 
 if __name__ == "__main__":
-    import sys
     if len(sys.argv) > 1:
         devicetree.parseFile(sys.argv[1]).pprint()


### PR DESCRIPTION
The default cache size enabled by `ParserElement.enablePackrat()` is 128 elements. Passing `None` removes this upper bound with the following results (using the devicetree-overlay-generator on the HiFive Unleashed as a benchmark):

```
$ /usr/bin/time -v ./scripts/devicetree-overlay-generator/generate_overlay.py bsp/sifive-hifive-unleashed/core.dts -o bsp/sifive-hifive-unleashed/design.dts -t hifive                                                                      
        Command being timed: "./scripts/devicetree-overlay-generator/generate_overlay.py bsp/sifive-hifive-unleashed/core.dts -o bsp/sifive-hifive-unleashed/design.dts -t hifive"
        User time (seconds): 1.73
        System time (seconds): 0.13
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:01.88
        ...
        Maximum resident set size (kbytes): 176704
        ...

$ /usr/bin/time -v ./scripts/devicetree-overlay-generator/generate_overlay.py bsp/sifive-hifive-unleashed/core.dts -o bsp/sifive-hifive-unleashed/design.dts -t hifive
        Command being timed: "./scripts/devicetree-overlay-generator/generate_overlay.py bsp/sifive-hifive-unleashed/core.dts -o bsp/sifive-hifive-unleashed/design.dts -t hifive"
        User time (seconds): 2.80
        System time (seconds): 0.01
        Percent of CPU this job got: 96%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.91
        ...
        Maximum resident set size (kbytes): 19364
        ...
```

Anecdotally we get a 35% speedup with 10x the maximum memory consumption, increasing from 20MB to 200MB.