### PR TITLE
Remove mypy dependence

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setuptools.setup(
 	],
 	python_requires=">=3.5",
         install_requires=[
-            "mypy",
             "pyparsing",
         ],
 )


### PR DESCRIPTION
`mypy` is a development dependence: it is not required by users of this package.

Closes #46 and closes #47 