### PR TITLE
Drop unsupported Python versions from CI; add new stable versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
This drops Python 3.5, 3.6, and 3.7 from the CI workflows, since they are all EOL. It adds 3.9, 3.10, and 3.11 as new versions we test against.