### PR TITLE
Update grammar.py to fix parsing errors

### DIFF
--- a/pydevicetree/source/grammar.py
+++ b/pydevicetree/source/grammar.py
@@ -21,7 +21,7 @@ p.ParserElement.enablePackrat(cache_bound)
 
 node_name = p.Word(p.alphanums + ",.-+_") ^ p.Literal("/")
 integer = p.pyparsing_common.integer ^ (p.Literal("0x").suppress() + p.pyparsing_common.hex_integer)
-unit_address = p.pyparsing_common.hex_integer
+unit_address = p.pyparsing_common.hex_integer ^ (p.Literal("0x").suppress() + p.pyparsing_common.hex_integer) ^ p.Word(p.alphanums + "_,")
 node_handle = node_name("node_name") + p.Optional(p.Literal("@") + unit_address("address"))
 property_name = p.Word(p.alphanums + ",.-_+?#")
 label = p.Word(p.alphanums + "_").setResultsName("label")


### PR DESCRIPTION
I encountered multiple parsing errors because the `unit_address` is considered being a hex value. This will fail on e.g. the following type of nodes.

node with a hex value but `0x` prefixed
```
uart@0x8000000 {
	compatible = "xlnx";
	reg = <0x1000>;
	interrupts = <0x3b 0x00>;
	clock = <0x2faf080>;
};
```

node using a variable name `some_var` instead of an address
```
uart@some_var {
	compatible = "xlnx";
	reg = <0x1000>;
	interrupts = <0x3b 0x00>;
	clock = <0x2faf080>;
};
```

node using invalid hex values (in the practice we saw multiple files using float values)
```
uart@0,0 {
	compatible = "xlnx";
	reg = <0x1000>;
	interrupts = <0x3b 0x00>;
	clock = <0x2faf080>;
};
```